### PR TITLE
Make sections settable for object editing purposes.

### DIFF
--- a/OsuParsers/Beatmaps/Beatmap.cs
+++ b/OsuParsers/Beatmaps/Beatmap.cs
@@ -8,16 +8,15 @@ namespace OsuParsers.Beatmaps
     public class Beatmap
     {
         public int Version { get; set; }
-        //TODO: make things in sections not "settable".
-        public GeneralSection GeneralSection { get; private set; }
-        public EditorSection EditorSection { get; private set; }
-        public MetadataSection MetadataSection { get; private set; }
-        public DifficultySection DifficultySection { get; private set; }
-        public EventsSection EventsSection { get; private set; }
+        public GeneralSection GeneralSection { get; set; }
+        public EditorSection EditorSection { get; set; }
+        public MetadataSection MetadataSection { get; set; }
+        public DifficultySection DifficultySection { get; set; }
+        public EventsSection EventsSection { get; set; }
 
-        public List<Color> Colours { get; private set; } = new List<Color>();
-        public List<TimingPoint> TimingPoints { get; private set; } = new List<TimingPoint>();
-        public List<HitObject> HitObjects { get; private set; } = new List<HitObject>();
+        public List<Color> Colours { get; set; } = new List<Color>();
+        public List<TimingPoint> TimingPoints { get; set; } = new List<TimingPoint>();
+        public List<HitObject> HitObjects { get; set; } = new List<HitObject>();
 
         public Beatmap()
         {


### PR DESCRIPTION
Any particular reason to make the setter private? I find it useful to be able to modify the sections for changing metadata information, adding new objects / modifying those objects, etc. Currently using this project to build a custom editor, so its useful to have all of the objects modifiable.