### PR TITLE
Compile only to .NET Standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/[Dd]ebug/
 [Bb]in/
 [Oo]bj/
 .vs/
+.vscode/

--- a/OsuParsers/OsuParsers.csproj
+++ b/OsuParsers/OsuParsers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <RootNamespace>OsuParsers</RootNamespace>
     <Authors>mrflashstudio</Authors>
     <Company />

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ PM> Install-Package OsuParsers
 ```
 
 # Building and Requirements
-- You need a desktop platform that can compile .NET 4.5 or higher.
+- You need a desktop platform that can compile .NET 4.6.1 or higher.
 - Clone the repository `git clone https://github.com/mrflashstudio/OsuParsers`
 - And then you can build the project in your IDE.
 


### PR DESCRIPTION
From my research, I've realized that .NET Standard supports .NET Framework 4.6.1, .NET Core 2.2, UWP 10.0.16299, Unity 2018.1
This makes the project much easier to compile on other platforms while still being cross platform.