### PR TITLE
Fix TimingPoint.Inherited parse

### DIFF
--- a/OsuParsers/Decoders/BeatmapDecoder.cs
+++ b/OsuParsers/Decoders/BeatmapDecoder.cs
@@ -316,7 +316,7 @@ namespace OsuParsers.Decoders
                 volume = Convert.ToInt32(tokens[5]);
 
             if (tokens.Length >= 7)
-                inherited = ParseHelper.ToBool(tokens[6]);
+                inherited = !ParseHelper.ToBool(tokens[6]);
 
             if (tokens.Length >= 8)
                 effects = (Effects)Convert.ToInt32(tokens[7]);


### PR DESCRIPTION
osu! docs indicate that the 6th token stores whether the current value
is *un*inherited. TimingPoint.Inherited was therefore inverted.