### PR TITLE
Fix BeatmapDecoder&StoryboardDecoder to use in parallel.

### DIFF
--- a/OsuParsers.Tests/Beatmaps.cs
+++ b/OsuParsers.Tests/Beatmaps.cs
@@ -73,6 +73,29 @@ namespace OsuParsers.Tests
             }
         }
 
+        public void ParallelParseAll()
+        {
+            var timerAll = new Stopwatch();
+            timerAll.Start();
+            Parallel.ForEach(RawFiles, file =>
+            {
+                var timer = new Stopwatch();
+                timer.Start();
+                var beatmap = BeatmapDecoder.Decode(file);
+                timer.Stop();
+                Maps.Add(beatmap);
+                Trace.WriteLine(string.Format(
+                    "Beatmap parsed in {0}ms: {1} - {2} [{3}] created by {4}.",
+                    timer.Elapsed.Milliseconds,
+                    beatmap.MetadataSection.Artist,
+                    beatmap.MetadataSection.Title,
+                    beatmap.MetadataSection.Version,
+                    beatmap.MetadataSection.Creator));
+            });
+            timerAll.Stop();
+            Trace.WriteLine($"All beatmaps parsed in {timerAll.Elapsed.Milliseconds}ms.");
+        }
+
         private string BaseUrl => @"https://osu.ppy.sh/osu/";
 
         private List<uint> BeatmapIDs =  new List<uint>
@@ -101,6 +124,15 @@ namespace OsuParsers.Tests
 
             Trace.WriteLine("Parsing beatmaps...");
             ParseAll();
+        }
+
+        [TestMethod]
+        public async Task ParseAllTestingBeatmapsParallel()
+        {
+            RawFiles.Clear();
+            await GetTestingBeatmaps();
+            Trace.WriteLine("Parsing beatmaps in parallel...");
+            ParallelParseAll();
         }
 
         [DataTestMethod]

--- a/OsuParsers/Decoders/BeatmapDecoder.cs
+++ b/OsuParsers/Decoders/BeatmapDecoder.cs
@@ -18,10 +18,6 @@ namespace OsuParsers.Decoders
 {
     public static class BeatmapDecoder
     {
-        private static Beatmap Beatmap;
-        private static FileSections currentSection = FileSections.None;
-        private static List<string> sbLines = new List<string>();
-
         /// <summary>
         /// Parses .osu file.
         /// </summary>
@@ -38,9 +34,28 @@ namespace OsuParsers.Decoders
         /// <summary>
         /// Parses .osu file.
         /// </summary>
+        /// <param name="stream">Stream containing beatmap data.</param>
+        /// <returns>A usable beatmap.</returns>
+        public static Beatmap Decode(Stream stream) => Decode(stream.ReadAllLines());
+
+        /// <summary>
+        /// Parses .osu file.
+        /// </summary>
         /// <param name="lines">Array of text lines containing beatmap data.</param>
         /// <returns>A usable beatmap.</returns>
         public static Beatmap Decode(IEnumerable<string> lines)
+        {
+            return new BeatmapDecodeTask().Run(lines);
+        }
+    }
+
+    internal class BeatmapDecodeTask 
+    {
+        private Beatmap Beatmap;
+        private FileSections currentSection = FileSections.None;
+        private List<string> sbLines = new List<string>();
+
+        public Beatmap Run(IEnumerable<string> lines)
         {
             Beatmap = new Beatmap();
             currentSection = FileSections.Format;
@@ -68,14 +83,7 @@ namespace OsuParsers.Decoders
             return Beatmap;
         }
 
-        /// <summary>
-        /// Parses .osu file.
-        /// </summary>
-        /// <param name="stream">Stream containing beatmap data.</param>
-        /// <returns>A usable beatmap.</returns>
-        public static Beatmap Decode(Stream stream) => Decode(stream.ReadAllLines());
-
-        private static void ParseLine(string line)
+        private void ParseLine(string line)
         {
             switch (currentSection)
             {
@@ -109,7 +117,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseGeneral(string line)
+        private void ParseGeneral(string line)
         {
             int index = line.IndexOf(':');
             string variable = line.Remove(index).Trim();
@@ -160,7 +168,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseEditor(string line)
+        private void ParseEditor(string line)
         {
             int index = line.IndexOf(':');
             string variable = line.Remove(index).Trim();
@@ -186,7 +194,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseMetadata(string line)
+        private void ParseMetadata(string line)
         {
             int index = line.IndexOf(':');
             string variable = line.Remove(index).Trim();
@@ -227,7 +235,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseDifficulty(string line)
+        private void ParseDifficulty(string line)
         {
             int index = line.IndexOf(':');
             string variable = line.Remove(index).Trim();
@@ -256,7 +264,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseEvents(string line)
+        private void ParseEvents(string line)
         {
             string[] tokens = line.Split(',');
 
@@ -290,7 +298,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseTimingPoints(string line)
+        private void ParseTimingPoints(string line)
         {
             string[] tokens = line.Split(',');
 
@@ -334,7 +342,7 @@ namespace OsuParsers.Decoders
             });
         }
 
-        private static void ParseColours(string line)
+        private void ParseColours(string line)
         {
             int index = line.IndexOf(':');
             string variable = line.Remove(index).Trim();
@@ -354,7 +362,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseHitObjects(string line)
+        private void ParseHitObjects(string line)
         {
             string[] tokens = line.Split(',');
 

--- a/OsuParsers/Decoders/StoryboardDecoder.cs
+++ b/OsuParsers/Decoders/StoryboardDecoder.cs
@@ -15,10 +15,6 @@ namespace OsuParsers.Decoders
 {
     public static class StoryboardDecoder
     {
-        private static Storyboard storyboard;
-        private static IStoryboardObject lastDrawable;
-        private static CommandGroup commandGroup;
-
         /// <summary>
         /// Parses .osb file.
         /// </summary>
@@ -35,9 +31,28 @@ namespace OsuParsers.Decoders
         /// <summary>
         /// Parses .osb file.
         /// </summary>
+        /// <param name="stream">Stream containing storyboard data.</param>
+        /// <returns>A usable storyboard.</returns>
+        public static Storyboard Decode(Stream stream) => Decode(stream.ReadAllLines());
+
+        /// <summary>
+        /// Parses .osb file.
+        /// </summary>
         /// <param name="lines">Array of text lines containing storyboard data.</param>
         /// <returns>A usable storyboard.</returns>
         public static Storyboard Decode(IEnumerable<string> lines)
+        {
+            return new StoryboardDecodeTask().Run(lines);
+        }
+    }
+    
+    internal class StoryboardDecodeTask
+    {
+        private Storyboard storyboard;
+        private IStoryboardObject lastDrawable;
+        private CommandGroup commandGroup;
+
+        public Storyboard Run(IEnumerable<string> lines)
         {
             storyboard = new Storyboard();
             lastDrawable = null;
@@ -65,14 +80,7 @@ namespace OsuParsers.Decoders
             return storyboard;
         }
 
-        /// <summary>
-        /// Parses .osb file.
-        /// </summary>
-        /// <param name="stream">Stream containing storyboard data.</param>
-        /// <returns>A usable storyboard.</returns>
-        public static Storyboard Decode(Stream stream) => Decode(stream.ReadAllLines());
-
-        private static string ParseVariables(string line)
+        private string ParseVariables(string line)
         {
             if (storyboard.Variables == null || line.IndexOf('$') < 0)
                 return line;
@@ -83,7 +91,7 @@ namespace OsuParsers.Decoders
             return line;
         }
 
-        private static void ParseSbObject(string line)
+        private void ParseSbObject(string line)
         {
             string[] tokens = line.Split(',');
 
@@ -129,7 +137,7 @@ namespace OsuParsers.Decoders
             }
         }
 
-        private static void ParseSbCommand(string line)
+        private void ParseSbCommand(string line)
         {
             int depth = 0;
             while (line.StartsWith(" ") || line.StartsWith("_"))


### PR DESCRIPTION
#43
Static fields cannot be used in parallel as temporary variables.